### PR TITLE
disconnect mutationObserver

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -206,6 +206,7 @@
             }
           });
           mutationObserver.observe(stickyElement, {subtree: true, childList: true});
+          $(stickyElement).data('sticky.mutationObserver', mutationObserver);
         } else {
           if (window.addEventListener) {
             stickyElement.addEventListener('DOMNodeInserted', function() {
@@ -239,6 +240,8 @@
             }
           }
           if(removeIdx !== -1) {
+            var mutationObserver = $(unstickyElement).data('sticky.mutationObserver');
+            mutationObserver.disconnect();
             unstickyElement.unwrap();
             unstickyElement
               .css({


### PR DESCRIPTION
Added code to disconnect the observer event: When a sticky is destroy it doesn't disconnect its observable instance, this affect others event that could be wrapped on the dom. This PR fix that issue for each sticky created.


